### PR TITLE
[Issue #330] Debugger node fails with error.

### DIFF
--- a/src/debugnode.erl
+++ b/src/debugnode.erl
@@ -12,7 +12,7 @@ main(TargetNodeName, TargetProcessName) ->
       exit(1);
     _ ->
       %%TODO check if node name contains host part
-      run({list_to_atom(TargetProcessName), list_to_atom(TargetNodeName ++ [$@|net_adm:localhost()])})
+      run({list_to_atom(TargetProcessName), list_to_atom(TargetNodeName ++ [$@|element(2,inet:gethostname())])})
   end.
 
 run(Debugger) ->


### PR DESCRIPTION
 Workaround for bug with net_adm:localhost() on some Linux platforms. Now it has been tested. This fix works.
See https://github.com/ignatov/intellij-erlang/issues/330
